### PR TITLE
Add support for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _NimHTTPd_ is a minimal web server that can be used to serve static files.
 
 ## Usage
 
-**nimhttpd** **[** **-6** **-p:**_port_ **-t:**_title_ **-a:**_address_ **]** **[** _directory_ **]**
+**nimhttpd** **[** **-6** **-p:**_port_ **-t:**_title_ **-a:**_address_  **-H**:_"key: val"_ **]** **[** _directory_ **]**
 
 Where:
 
@@ -19,3 +19,4 @@ Where:
 - _address_ is the address to bind to (default: 0.0.0.0).
 - _title_ is the title to use when listing the contents of a directory.
 - _-6_ enables IPv6 support
+- _-H_  is a custom header (Specified like in curl)

--- a/src/nimhttpd.nim
+++ b/src/nimhttpd.nim
@@ -10,7 +10,7 @@ import
   uri,
   strscans
   
-from httpcore import HttpMethod, HttpHeaders
+from httpcore import HttpMethod, HttpHeaders, parseHeader
 
 import
   nimhttpdpkg/config
@@ -227,12 +227,8 @@ when isMainModule:
             echo "Error: Invalid port: '", val, "'"
             echo "Running on default port instead."
       of "header", "H":
-        var key, value: string
-        if val.scanf("$+: $+", key, value):
-          headers[key] = value
-        else:
-          echo "Invalid header ", val, " passed. Should be in the form \"key: value\""
-          quit QuitFailure
+        let (key, values) = parseHeader(val)
+        headers[key] = values
       else:
         discard
     of cmdArgument:

--- a/src/nimhttpd.nim
+++ b/src/nimhttpd.nim
@@ -7,7 +7,8 @@ import
   parseopt,
   strutils, 
   times, 
-  uri
+  uri,
+  strscans
   
 from httpcore import HttpMethod, HttpHeaders
 
@@ -40,6 +41,7 @@ let usage = """ $1 v$2 - $3
     -a, --address  The address to listen to (default: $6). If the specified port is
                    unavailable, the number will be incremented until an available port is found.
     -6, --ipv6     Listen to IPv6 addresses.
+    -H  --header   Add a custom header. Multiple headers can be added
 """ % [name, version, description, author, $portDefault, $addressDefault]
 
 
@@ -57,7 +59,7 @@ type
     address*: string
     name*: string
     version*: string
-
+    headers*: HttpHeaders
 proc h_page(settings:NimHttpSettings, content, title, subtitle: string): string =
   var footer = """<div id="footer">$1 v$2</div>""" % [settings.name, settings.version]
   result = """
@@ -172,6 +174,7 @@ proc serve*(settings: NimHttpSettings) =
     printReqInfo(settings, req)
     let path = settings.directory/req.url.path.replace("%20", " ").decodeUrl()
     var res: NimHttpResponse 
+    res.headers = settings.headers
     if req.reqMethod != HttpGet:
       res = sendNotImplemented(settings, path)
     elif path.dirExists:
@@ -180,6 +183,8 @@ proc serve*(settings: NimHttpSettings) =
       res = sendStaticFile(settings, path)
     else:
       res = sendNotFound(settings, path)
+    for key, value in settings.headers:
+      res.headers[key] = value
     await req.respond(res.code, res.content, res.headers)
   echo genMsg(settings)
   asyncCheck server.serve(settings.port, handleHttpRequest, settings.address, -1, domain)
@@ -191,6 +196,7 @@ when isMainModule:
   var logging = false
   var www = getCurrentDir()
   var title = "Index"
+  var headers = newHttpHeaders()
   
   for kind, key, val in getopt():
     case kind
@@ -220,6 +226,13 @@ when isMainModule:
           else:
             echo "Error: Invalid port: '", val, "'"
             echo "Running on default port instead."
+      of "header", "H":
+        var key, value: string
+        if val.scanf("$+: $+", key, value):
+          headers[key] = value
+        else:
+          echo "Invalid header ", val, " passed. Should be in the form \"key: value\""
+          quit QuitFailure
       else:
         discard
     of cmdArgument:
@@ -251,6 +264,7 @@ when isMainModule:
   settings.title = title
   settings.version = version
   settings.port = Port(port)
-  
+  settings.headers = headers
+
   serve(settings)
   runForever()


### PR DESCRIPTION
Needed custom headers when working with `SharedArrayBuffer` and ran into problems when I couldn't set [needed headers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements). Saw someone in the Nim discord having similar problems so decided to add support

```cmd
nimhttpd --header:"custom: val"
```
Curl 
```cmd
curl http://127.0.0.1:1337/README.md -v
*   Trying 127.0.0.1:1337...
* Connected to 127.0.0.1 (127.0.0.1) port 1337 (#0)
> GET /README.md HTTP/1.1
> Host: 127.0.0.1:1337
> User-Agent: curl/7.86.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-type: text/markdown
< custom: val
< Content-Length: 1054
```
