### PR TITLE
Dual-stack nimhttpd

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 Fabio Cevasco
+Copyright (c) 2015-2023 Fabio Cevasco
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ _NimHTTPd_ is a minimal web server that can be used to serve static files.
 
 ## Usage
 
-**nimhttpd** **[** **-6** **-p:**_port_ **-t:**_title_ **-a:**_address_  **-H**:_"key: val"_ **]** **[** _directory_ **]**
+**nimhttpd** **[** **-p:**_port_ **-t:**_title_ **-a:**_address_ **-6:**_ipv6_ **-H**:_"key: val"_ **]** **[** _directory_ **]**
 
 Where:
 
 - _directory_ is the directory to serve (default: current directory).
 - _port_ is the port to listen to (default: 1337). If the specified port is
   unavailable, the number will be incremented until an available port is found.
-- _address_ is the address to bind to (default: 0.0.0.0).
+- _address_ is the address to bind to (default: localhost; use "0.0.0.0" to accept any IPv4 address).
+- _ipv6_ is the IPv6 address to bind to (default: localhost; use "::" to accept any IPv6 address).
 - _title_ is the title to use when listing the contents of a directory.
-- _-6_ enables IPv6 support
 - _-H_  is a custom header (Specified like in curl)

--- a/src/nimhttpd.nim
+++ b/src/nimhttpd.nim
@@ -1,11 +1,12 @@
 import 
   asyncdispatch,
-  asynchttpserver, 
+  asynchttpserver,
+  macros,
   mimetypes, 
   nativesockets,
   os,
   parseopt,
-  strutils, 
+  strutils,
   times, 
   uri
   
@@ -109,20 +110,20 @@ proc sendNotImplemented(settings: NimHttpSettings, path: string): NimHttpRespons
   return (code: Http501, content: hPage(settings, content, $int(Http501), "Not Implemented"), headers: {"Content-Type": "text/html"}.newHttpHeaders())
 
 proc sendStaticFile(settings: NimHttpSettings, path: string): NimHttpResponse =
-  let mimes = settings.mimes
-  var ext = path.splitFile.ext
-  if ext == "":
-    ext = ".txt"
-  ext = ext[1 .. ^1]
+  var
+    mimes = settings.mimes
+    ext = path.splitFile.ext
+  if ext == "": ext = ".txt" else: ext = ext[1 .. ^1]
   let mimetype = mimes.getMimetype(ext.toLowerAscii)
   var file = path.readFile
   return (code: Http200, content: file, headers: {"Content-Type": mimetype}.newHttpHeaders)
 
 proc sendDirContents(settings: NimHttpSettings, dir: string): NimHttpResponse = 
-  let cwd = settings.directory.absolutePath
-  var res: NimHttpResponse
-  var files = newSeq[string](0)
-  var path = dir.absolutePath
+  var
+    res: NimHttpResponse
+    cwd = settings.directory.absolutePath
+    files = newSeq[string](0)
+    path = dir.absolutePath
   if not path.startsWith(cwd):
     path = cwd
   if path != cwd and path != cwd&"/" and path != cwd&"\\":

--- a/src/nimhttpdpkg/config.nim
+++ b/src/nimhttpdpkg/config.nim
@@ -1,5 +1,5 @@
 const
   pkgTitle*       = "NimHTTPd"
-  pkgVersion*     = "1.4.1"
+  pkgVersion*     = "1.5.0"
   pkgAuthor*      = "Fabio Cevasco & Michael Adams"
   pkgDescription* = "A tiny static file web server. IPv4 & IPv6 supported!"

--- a/src/nimhttpdpkg/config.nim
+++ b/src/nimhttpdpkg/config.nim
@@ -1,5 +1,5 @@
 const
   pkgTitle*       = "NimHTTPd"
-  pkgVersion*     = "1.4.0"
+  pkgVersion*     = "1.4.1"
   pkgAuthor*      = "Fabio Cevasco & Michael Adams"
   pkgDescription* = "A tiny static file web server. IPv4 & IPv6 supported!"


### PR DESCRIPTION
@h3rald , I hope you're doing well. It was bugging me that this app couldn't do dual-stack IPv4+IPv6, so I figured out how to make that work. Now it will default open two threads: one for each address family and the -6 flag is now used to set the listening IPv6 address. Setting **-a:"0.0.0.0"** and **-6:"::"** correctly resolves either protocol & their addresses for me.